### PR TITLE
Add message directing people to hnix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 Straightforward library for parsing Nix and pretty-printing.
+
+### This library is no longer maintained
+
+All functionality from this library (and more) is now in [hnix](https://github.com/jwiegley/hnix), which is where I am contributing improvements.


### PR DESCRIPTION
I noticed that hnix basically has a superset of the functionality of this library, and you are contributing to it nowadays instead of working on simple-nix. So I thought it might be good to have a message directing people to the better library.

@adnelson 
